### PR TITLE
Reacondicionado docs Rust

### DIFF
--- a/src/content/docs/guides/example/CursoRust.md
+++ b/src/content/docs/guides/example/CursoRust.md
@@ -3,17 +3,26 @@ title: Curso Rust
 description: Guia basica para aprender rust
 ---
 
-# Curso Completo de Rust
-
 ## Índice del Curso
 
 1. [Introducción al Curso](#introducción-al-curso)
+    1. [Objetivo del Curso](#objetivo-del-Curso)
 2. [Instalación](#instalación)
+    1. [Instalación de Rust](#instalación-de-rust)
 3. [Tu Primer Hello World](#tu-primer-hello-world)
+    1. [Código de Ejemplo](#código-de-ejemplo)
 4. [Cargo: Gestor de Paquetes y Build System de Rust](#cargo-gestor-de-paquetes-y-build-system-de-rust)
+    1. [Iniciar un Proyecto con Cargo](#iniciar-un-proyecto-con-cargo)
 5. [Selección del IDE](#selección-del-ide)
+    1. [Configuración de Visual Studio Code para Rust](#configuración-de-visual-studio-code-para-rust)
 6. [Conceptos Fundamentales](#conceptos-fundamentales)
+    1. [Variables, Inmutabilidad y Constantes](#variables-inmutabilidad-y-constantes)
+    2. [Funciones](#funciones)
+    3. [Structs](#structs)
+    4. [Explicación](#explicación)
 7. [Flujos de Control](#flujos-de-control)
+    1. [if-else](#if-else)
+<!-- 
 8. [Collections](#collections)
 9. [Concepto de Ownership en Rust](#concepto-de-ownership-en-rust)
 10. [Smart Pointers: Mucho Más que Referencias](#smart-pointers-mucho-más-que-referencias)
@@ -25,16 +34,19 @@ description: Guia basica para aprender rust
 16. [Segunda Aplicación Rust](#segunda-aplicación-rust)
 17. [Construyendo una API de Twitter](#construyendo-una-api-de-twitter)
 18. [WebAssembly: Construye Apps para la Web con Rust](#webassembly-construye-apps-para-la-web-con-rust)
-19. [Contenido Adicional](#contenido-adicional)
+19. [Contenido Adicional](#contenido-adicional) 
+-->
 
 ## Introducción al Curso
 
-**Objetivo del Curso:**
+### Objetivo del Curso
+
 Este curso tiene como objetivo enseñarte Rust desde lo más básico hasta construir aplicaciones avanzadas. Rust es un lenguaje de programación de sistemas enfocado en la seguridad y el rendimiento.
 
 ## Instalación
 
-**Instalación de Rust:**
+### Instalación de Rust
+
 Para instalar Rust, utiliza `rustup`, el instalador de Rust:
 
 ```bash
@@ -49,9 +61,9 @@ rustc --version
 
 ## Tu Primer Hello World
 
-**Código de Ejemplo:**
+### Código de Ejemplo
 
-```bash
+```rs
 fn main() {
     // Esta línea imprime "Hello, world!" en la consola
     println!("Hello, world!");
@@ -60,7 +72,8 @@ fn main() {
 
 ## Cargo: Gestor de Paquetes y Build System de Rust
 
-**Iniciar un Proyecto con Cargo:**
+### Iniciar un Proyecto con Cargo
+
 Cargo es la herramienta de Rust para gestionar proyectos.
 
 ```bash
@@ -72,18 +85,18 @@ cargo run
 
 ## Selección del IDE
 
-**Configuración de Visual Studio Code para Rust:**
+### Configuración de Visual Studio Code para Rust
 
 Instala la extensión "rust-analyzer" en VSCode.
 Configura el debugger siguiendo la documentación oficial de VSCode y Rust <a href="https://code.visualstudio.com/docs/languages/rust" target="_blank">documentación oficial de VSCode y Rust</a>.
 
 ## Conceptos Fundamentales
 
-**Variables, Inmutabilidad y Constantes:**
+### Variables, Inmutabilidad y Constantes
 
 En Rust, las variables son inmutables por defecto, lo que significa que no puedes cambiar su valor una vez asignado. Si deseas que una variable sea mutable, debes usar la palabra clave mut. Además, Rust permite definir constantes con const, las cuales deben tener un tipo explícito y su valor no puede cambiar.
 
-```bash
+```rs
 fn main() {
     let x = 5; // x es inmutable, no se puede cambiar su valor una vez asignado
     let mut y = 10; // y es mutable, se puede cambiar su valor más adelante
@@ -91,11 +104,11 @@ fn main() {
 }
 ```
 
-**Funciones**
+### Funciones
 
 Las funciones en Rust se definen con la palabra clave fn, seguida del nombre de la función y los parámetros. El tipo de retorno se especifica después de la flecha ->. En este ejemplo, suma es una función que toma dos enteros como parámetros y retorna su suma.
 
-```bash
+```rs
 fn main() {
     println!("El resultado es: {}", suma(5, 3)); // llama a la función suma y muestra el resultado
 }
@@ -105,11 +118,11 @@ fn suma(a: i32, b: i32) -> i32 {
 }
 ```
 
-**Structs**
+### Structs
 
 Los structs en Rust permiten agrupar varios valores en una única estructura. En este ejemplo, Usuario es un struct con dos campos: nombre y edad. Luego, se crea una instancia de Usuario y se imprimen sus valores.
 
-```bash
+```rs
 // Definición del struct Usuario
 // Un struct es una colección de múltiples datos agrupados bajo un mismo nombre
 struct Usuario {
@@ -129,7 +142,7 @@ fn main() {
 }
 ```
 
-**Explicación**
+### Explicación
 
 Variables y Mutabilidad: En Rust, las variables son inmutables por defecto. Si necesitas cambiar el valor de una variable, debes declararla como mutable usando mut.
 
@@ -141,7 +154,7 @@ Structs: Permiten agrupar datos relacionados en una única estructura. Los struc
 
 ## Flujos de Control
 
-**if-else:**
+### if-else
 
 Declaración de Variables:
 
@@ -155,7 +168,7 @@ Si la condición es falsa, se ejecuta el bloque de código dentro del else y se 
 
 El uso de if-else permite tomar decisiones en el flujo del programa basado en condiciones booleanas. Este ejemplo muestra cómo evaluar una condición y ejecutar diferentes bloques de código en función del resultado de esa evaluación.
 
-```bash
+```rs
 fn main() {
     let numero = 7; // Se declara una variable inmutable llamada numero y se le asigna el valor 7
 

--- a/src/content/docs/guides/rust/01-introduccion.md
+++ b/src/content/docs/guides/rust/01-introduccion.md
@@ -1,0 +1,53 @@
+---
+title: Introducción al Curso
+description: Guia basica para aprender rust
+---
+
+## Objetivo del Curso
+
+Este curso tiene como objetivo enseñarte Rust desde lo más básico hasta construir aplicaciones avanzadas. Rust es un lenguaje de programación de sistemas enfocado en la seguridad y el rendimiento.
+
+## Instalación
+
+Para instalar Rust, utiliza `rustup`, el instalador de Rust:
+
+```bash
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+```
+
+**Después de instalar Rust, asegúrate de que está correctamente instalado:**
+
+```bash
+rustc --version
+```
+
+## Selección del IDE
+
+### Configuración de Visual Studio Code para Rust
+
+Instala la extensión "rust-analyzer" en VSCode.
+Configura el debugger siguiendo la documentación oficial de VSCode y Rust <a href="https://code.visualstudio.com/docs/languages/rust" target="_blank">documentación oficial de VSCode y Rust</a>.
+
+## Tu Primer Hello World
+
+### Código de Ejemplo
+
+```rs
+fn main() {
+    // Esta línea imprime "Hello, world!" en la consola
+    println!("Hello, world!");
+}
+```
+
+## Cargo: Gestor de Paquetes y Build System de Rust
+
+### Iniciar un Proyecto con Cargo
+
+Cargo es la herramienta de Rust para gestionar proyectos.
+
+```bash
+cargo new hello_cargo
+cd hello_cargo
+cargo build
+cargo run
+```

--- a/src/content/docs/guides/rust/02-conceptos-fundamentales.md
+++ b/src/content/docs/guides/rust/02-conceptos-fundamentales.md
@@ -1,0 +1,92 @@
+---
+title: Conceptos Fundamentales
+---
+
+## Variables, Inmutabilidad y Constantes
+
+En Rust, las variables son inmutables por defecto, lo que significa que no puedes cambiar su valor una vez asignado. Si deseas que una variable sea mutable, debes usar la palabra clave mut. Además, Rust permite definir constantes con const, las cuales deben tener un tipo explícito y su valor no puede cambiar.
+
+```rs
+fn main() {
+    let x = 5; // x es inmutable, no se puede cambiar su valor una vez asignado
+    let mut y = 10; // y es mutable, se puede cambiar su valor más adelante
+    const MAX_POINTS: u32 = 100_000; // constante, su valor no puede cambiar y se debe declarar con tipo
+}
+```
+
+Variables y Mutabilidad: En Rust, las variables son inmutables por defecto. Si necesitas cambiar el valor de una variable, debes declararla como mutable usando mut.
+
+Constantes: Se declaran usando const y siempre deben tener un tipo explícito. Su valor no puede cambiar una vez asignado.
+
+## Funciones
+
+Las funciones en Rust se definen con la palabra clave fn, seguida del nombre de la función y los parámetros. El tipo de retorno se especifica después de la flecha ->. En este ejemplo, suma es una función que toma dos enteros como parámetros y retorna su suma.
+
+```rs
+fn main() {
+    println!("El resultado es: {}", suma(5, 3)); // llama a la función suma y muestra el resultado
+}
+
+fn suma(a: i32, b: i32) -> i32 {
+    a + b // retorna la suma de a y b
+}
+```
+
+Se definen con fn y pueden tomar parámetros y retornar valores. El tipo de retorno se especifica después de la flecha ->.
+
+## Structs
+
+Los structs en Rust permiten agrupar varios valores en una única estructura. En este ejemplo, Usuario es un struct con dos campos: nombre y edad. Luego, se crea una instancia de Usuario y se imprimen sus valores.
+
+```rs
+// Definición del struct Usuario
+// Un struct es una colección de múltiples datos agrupados bajo un mismo nombre
+struct Usuario {
+    nombre: String, // campo nombre de tipo String
+    edad: u32,      // campo edad de tipo u32 (entero sin signo de 32 bits)
+}
+
+fn main() {
+    // Creación de una instancia del struct Usuario
+    let usuario = Usuario {
+        nombre: String::from("Alice"), // inicializa el campo nombre con el valor "Alice"
+        edad: 30,                      // inicializa el campo edad con el valor 30
+    };
+
+    // Imprime los detalles del usuario en la consola
+    println!("Usuario: {}, Edad: {}", usuario.nombre, usuario.edad); // imprime los detalles del usuario
+}
+```
+
+Permiten agrupar datos relacionados en una única estructura. Los structs son útiles para organizar y manipular datos de manera más estructurada.
+
+## Flujos de Control
+
+### if-else
+
+Declaración de Variables:
+
+Se declara una variable inmutable numero y se le asigna el valor 7.
+
+Estructura if-else:
+
+La estructura if evalúa si la condición numero < 5 es verdadera.
+Si la condición es verdadera, se ejecuta el bloque de código dentro del if y se imprime "Menor que 5".
+Si la condición es falsa, se ejecuta el bloque de código dentro del else y se imprime "Mayor o igual a 5".
+
+El uso de if-else permite tomar decisiones en el flujo del programa basado en condiciones booleanas. Este ejemplo muestra cómo evaluar una condición y ejecutar diferentes bloques de código en función del resultado de esa evaluación.
+
+```rs
+fn main() {
+    let numero = 7; // Se declara una variable inmutable llamada numero y se le asigna el valor 7
+
+    // Inicio de la estructura if-else
+    if numero < 5 {
+        // Si la condición numero < 5 es verdadera, se ejecuta este bloque
+        println!("Menor que 5");
+    } else {
+        // Si la condición numero < 5 es falsa, se ejecuta este bloque
+        println!("Mayor o igual a 5");
+    }
+}
+```

--- a/src/content/docs/guides/rust/index.md
+++ b/src/content/docs/guides/rust/index.md
@@ -1,0 +1,23 @@
+---
+title: Curso Rust
+description: Guia basica para aprender rust
+---
+
+## Índice del Curso
+
+1. [Introducción al Curso](01-introduccion)
+    1. [Objetivo del Curso](01-introduccion#objetivo-del-Curso)
+    2. [Instalación](01-introduccion#instalación)
+    3. [Selección del IDE](01-introduccion#selección-del-ide)
+        1. [Configuración de Visual Studio Code para Rust](01-introduccion#configuración-de-visual-studio-code-para-rust)
+    4. [Tu Primer Hello World](01-introduccion#tu-primer-hello-world)
+        1. [Código de Ejemplo](01-introduccion#código-de-ejemplo)
+    5. [Cargo: Gestor de Paquetes y Build System de Rust](01-introduccion#cargo-gestor-de-paquetes-y-build-system-de-rust)
+        1. [Iniciar un Proyecto con Cargo](01-introduccion#iniciar-un-proyecto-con-cargo)
+
+2. [Conceptos Fundamentales](02-conceptos-fundamentales)
+    1. [Variables, Inmutabilidad y Constantes](02-conceptos-fundamentales#variables-inmutabilidad-y-constantes)
+    2. [Funciones](02-conceptos-fundamentales#funciones)
+    3. [Structs](02-conceptos-fundamentales#structs)
+    5. [Flujos de Control](02-conceptos-fundamentales#flujos-de-control)
+        1. [if-else](02-conceptos-fundamentales#if-else)


### PR DESCRIPTION
Paco he dividido la documentación de Rust en 3 secciones: índice, introducción y conceptos fundamentales. Ahora cada sección es una página independiente. Echale un ojo y si t mola hazle un merge

On branch feature/rust-course

Changes to be committed:
	renamed:    src/content/docs/guides/CursoRust.md -> src/content/docs/guides/example/CursoRust.md
	new file:   src/content/docs/guides/rust/01-introduccion.md
	new file:   src/content/docs/guides/rust/02-conceptos-fundamentales.md
	new file:   src/content/docs/guides/rust/index.md